### PR TITLE
@craigspaeth - Renders json only if request content-type is json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-error-handler",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Error handling routes for use in Artsy's web apps.",
   "keywords": [
     "handler",

--- a/routes.coffee
+++ b/routes.coffee
@@ -19,7 +19,7 @@ module.exports.internalError = (err, req, res, next) ->
   debug err.stack
   res.status err.status or 500
   detail = err.message or err.text or err.toString()
-  if req.accepts 'application/json'
+  if req.is('application/json')
     res.send
       code: res.statusCode
       message: detail

--- a/test/error_handler.coffee
+++ b/test/error_handler.coffee
@@ -12,7 +12,7 @@ describe '#internalError', ->
 
   beforeEach ->
     @req =
-      accepts: sinon.stub()
+      is: sinon.stub()
     @res =
       statusCode: 500
       send: sinon.spy()
@@ -36,7 +36,7 @@ describe '#internalError', ->
     @res.status.args[0][0].should.equal 404
 
   it 'sends json', ->
-    @req.accepts.returns 'application/json'
+    @req.is.returns true
     errorHandler.internalError new Error("Some blah error"), @req, @res
     @res.send.args[0][0].message.should.equal "Some blah error"
 


### PR DESCRIPTION
Apparently `accepts` is going to be true more often than expected. I encountered this error page this morning:
![screenshot 2016-12-01 09 36 44](https://cloud.githubusercontent.com/assets/821469/20797803/69fa8e54-b7aa-11e6-8f48-04423b619852.png)

This PR checks the request `content-type` rather than if the request _can_ accept json. See http://expressjs.com/en/api.html#req.is
